### PR TITLE
avoid lower-casing files_to_attach field

### DIFF
--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -235,7 +235,7 @@ class EmailNotification(models.Model):
     def attach_files(self, email: EmailMultiAlternatives, form):
         """Attach files if any are needed"""
         files_to_attach = serialize_delimiter_separated_values_string(
-            self.files_to_attach_to_email, delimiter=",", strip=True, lower=True
+            self.files_to_attach_to_email, delimiter=",", strip=True, lower=False
         )
         if not files_to_attach:
             return

--- a/aldryn_forms/validators.py
+++ b/aldryn_forms/validators.py
@@ -14,13 +14,14 @@ def generate_file_extension_validator(allowed_extensions_str: str = ""):
     allowed_extensions = serialize_delimiter_separated_values_string(
         allowed_extensions_str, delimiter=",", strip=True, lower=True
     )
+
+    if not allowed_extensions:
+        return lambda value: None
+
     allowed_extensions = [
         extension if extension.startswith(".") else f".{extension}"
         for extension in allowed_extensions
     ]
-
-    if not allowed_extensions:
-        return lambda value: None
 
     def validator(value):
         extension = os.path.splitext(value.name)[1]  # [0] returns path+filename


### PR DESCRIPTION
Aldryn form fields can have names with upper-case characters. The delimiter-separated values serializer now does not automatically lower-case the list of files variables it receives.

Also changed the order of returning an open validator function for allowed extensions. Very minor change but could avoid freak cases where a None is found in allowed_extensions field