### PR TITLE
create a copy of in-memory file to avoid unpredictability

### DIFF
--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -1,3 +1,4 @@
+import io
 from typing import Dict
 
 from PIL import Image
@@ -547,10 +548,10 @@ class EmailField(BaseTextField):
     form_field_widget = forms.EmailInput
     form_field_widget_input_type = 'email'
     fieldset_advanced_fields = [
-        'email_send_notification',
-        'email_subject',
-        'email_body',
-    ] + Field.fieldset_advanced_fields
+                                   'email_send_notification',
+                                   'email_subject',
+                                   'email_body',
+                               ] + Field.fieldset_advanced_fields
     email_template_base = 'aldryn_forms/emails/user/notification'
 
     def send_notification_email(self, email, form, form_field_instance):
@@ -590,8 +591,8 @@ class FileField(Field):
         'validators',
     ]
     fieldset_general_fields = [
-        'upload_to',
-    ] + Field.fieldset_general_fields
+                                  'upload_to',
+                              ] + Field.fieldset_general_fields
     fieldset_advanced_fields = [
         'store_to_filer',
         'help_text',
@@ -633,6 +634,8 @@ class FileField(Field):
         field_name = form.form_plugin.get_form_field_name(field=instance)
 
         uploaded_file: InMemoryUploadedFile = form.cleaned_data[field_name]
+        copy = io.BytesIO(uploaded_file.read())
+        uploaded_file.seek(0)
 
         if uploaded_file is None:
             return
@@ -662,7 +665,8 @@ class FileField(Field):
 
             form.cleaned_data[field_name] = filer_file
 
-        form.cleaned_data[f"{field_name}__in_memory"] = uploaded_file
+        uploaded_file.close()
+        form.cleaned_data[f"{field_name}__in_memory"] = {"name": uploaded_file.name, "file": copy}
 
 
 class ImageField(FileField):
@@ -673,8 +677,8 @@ class ImageField(FileField):
     form_field = RestrictedImageField
     form_field_widget = RestrictedImageField.widget
     fieldset_general_fields = [
-        'upload_to',
-    ] + Field.fieldset_general_fields
+                                  'upload_to',
+                              ] + Field.fieldset_general_fields
     fieldset_advanced_fields = [
         'store_to_filer',
         'help_text',
@@ -874,6 +878,7 @@ else:
         def serialize_field(self, *args, **kwargs):
             # None means don't serialize me
             return None
+
 
     plugin_pool.register_plugin(CaptchaField)
 

--- a/aldryn_forms/cms_plugins.py
+++ b/aldryn_forms/cms_plugins.py
@@ -548,10 +548,10 @@ class EmailField(BaseTextField):
     form_field_widget = forms.EmailInput
     form_field_widget_input_type = 'email'
     fieldset_advanced_fields = [
-                                   'email_send_notification',
-                                   'email_subject',
-                                   'email_body',
-                               ] + Field.fieldset_advanced_fields
+        "email_send_notification",
+        "email_subject",
+        "email_body",
+    ] + Field.fieldset_advanced_fields
     email_template_base = 'aldryn_forms/emails/user/notification'
 
     def send_notification_email(self, email, form, form_field_instance):
@@ -591,8 +591,8 @@ class FileField(Field):
         'validators',
     ]
     fieldset_general_fields = [
-                                  'upload_to',
-                              ] + Field.fieldset_general_fields
+        "upload_to",
+    ] + Field.fieldset_general_fields
     fieldset_advanced_fields = [
         'store_to_filer',
         'help_text',
@@ -677,8 +677,8 @@ class ImageField(FileField):
     form_field = RestrictedImageField
     form_field_widget = RestrictedImageField.widget
     fieldset_general_fields = [
-                                  'upload_to',
-                              ] + Field.fieldset_general_fields
+        "upload_to",
+    ] + Field.fieldset_general_fields
     fieldset_advanced_fields = [
         'store_to_filer',
         'help_text',

--- a/aldryn_forms/contrib/email_notifications/models.py
+++ b/aldryn_forms/contrib/email_notifications/models.py
@@ -1,3 +1,4 @@
+import io
 import mimetypes
 import typing
 from email.utils import formataddr
@@ -253,14 +254,20 @@ class EmailNotification(models.Model):
             field_name = field._model_instance.name
 
             if field_name in files_to_attach:
-                field_file_handler_name = f"{field_name}__in_memory"
-                file: InMemoryUploadedFile = form.cleaned_data.get(field_file_handler_name)
+                field_file_key = f"{field_name}__in_memory"
+                filed_file_data: typing.Dict[str, typing.Union[str, io.BytesIO]] = form.cleaned_data.get(field_file_key)
+                file = filed_file_data["file"]
+                file_name = filed_file_data["name"]
                 if not file:
                     continue
+
+                # Redundant precaution
+                file.seek(0)
+
                 email.attach(
-                    filename=file.name,
+                    filename=file_name,
                     content=file.read(),
-                    mimetype=mimetypes.guess_type(file.name)[0],
+                    mimetype=mimetypes.guess_type(file_name)[0],
                 )
 
     def prepare_email(self, form):


### PR DESCRIPTION
In response to IO errors that are caused presumably due to filer closing the InMemoryUploadFile after processing it